### PR TITLE
Update Database_Management_Foundations_Study_Guide.md

### DIFF
--- a/D426_Database_Management_Foundations/Database_Management_Foundations_Study_Guide.md
+++ b/D426_Database_Management_Foundations/Database_Management_Foundations_Study_Guide.md
@@ -666,7 +666,7 @@ FULL JOIN table2 t2
 ```
 
 - **LEFT JOIN**
-  - `LEFT JOIN` selects **all left table rows**, but only matching left table rows.
+  - `LEFT JOIN` selects **all left table rows**, but only matching right table rows.
 
 ```sql
 SELECT


### PR DESCRIPTION
Fixed LEFT JOIN description. Said all left table rows and only matching left table rows. Needed to say right table rows